### PR TITLE
The "onMouseMove" override was broken

### DIFF
--- a/src/jTimeout.js
+++ b/src/jTimeout.js
@@ -342,7 +342,7 @@
                             timeout.mouseMoved = false;
                         }, inMS);
 
-                        if (!timeout.onMouseMove)
+                        if (!options.onMouseMove)
                         {
                             $.get(options.extendUrl);
 


### PR DESCRIPTION
Line 345 was `if (!timeout.onMouseMove)` when it should have been `if (!options.onMouseMove`, which caused overrides to fail.