### PR TITLE
Allow jQuery 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://htmlguyllc.github.io/jTimeout/",
   "private": false,
   "dependencies": {
-    "jquery": "^1.7.1"
+    "jquery": ">=1.7.1 <4.0.0"
   },
   "license":{
     "type": "MIT",


### PR DESCRIPTION
But not 4.x

Per https://jubianchi.github.io/semver-check/#/%3E%3D1.7.1%20%3C4.0.0/3.3.1 this change should work.