### PR TITLE
Add a destructor

### DIFF
--- a/src/jTimeout.js
+++ b/src/jTimeout.js
@@ -180,7 +180,7 @@
                     timeout.setMouseTimeout(window.setTimeout(function ()
                     {
                         //on mouse move
-                        $('body').on('mousemove', function ()
+                        $('body').on('mousemove.jTimeout', function ()
                         {
                             if (!timeout.mouseMoved && timeout.resetOnAlert())
                             {
@@ -245,6 +245,16 @@
                     timeout.stopPriorCountdown();
                     timeout.hideCountdownAlert();
                 }
+            },
+            /* When you are all done, destroy all the timers -- or just let the user navigate away from the page. */
+            destructor: function () {
+                timeout.stopFlashing();
+                timeout.stopActivityMonitoring();
+                delete timeout.options.onSessionExtended;
+                delete timeout.countdown;
+
+                // Remove the event handlers
+                $('body').off('mousemove.jTimeout');
             }
         };
 


### PR DESCRIPTION
I'm not sure how you feel about this... Our implementation allows the users to close the timeout notification  (`#jTimedoutAlert`) and remain on the page after the server has terminated their session. In order to achieve this, I had to namespace the `mousemove` event so it could be removed if they closed the alert.  this is done in our code by customizing the jAlert with `'closeBtn': true` and providing an `onClose` function. Without this destructor, moving the mouse re-creates countdowns and it tries to keep tracking and updating a session that has terminated. 

Do you feel there are other elements that should be destroyed by such a method?

If you don't like the destructor, can I at least get the namespaced `mousemove` event? 