### PR TITLE
Update jTimeout.js - close tab across multiple windows when not using jAlert

### DIFF
--- a/src/jTimeout.js
+++ b/src/jTimeout.js
@@ -133,20 +133,6 @@
             {
                 timeout.priorCountDown = elem;
             },
-            /**
-             * Hides the countdown alert
-             */
-            hideCountdownAlert: function()
-            {
-                timeout.timeoutWarning = false;
-
-                var timeoutAlert = $('#jTimeoutAlert');
-
-                if (timeoutAlert.length > 0)
-                {
-                    timeoutAlert.closeAlert();
-                }
-            },
             setMouseTimeout: function(timeout)
             {
                 this.mouseTimeout = timeout;
@@ -241,7 +227,7 @@
                 {
                     timeout.stopFlashing();
                     timeout.stopPriorCountdown();
-                    timeout.hideCountdownAlert();
+                    timeout.options.hideCountdownAlert();
                 }
             },
             /* Kill the plugin by removing all event handlers and current activities (like flashing) */
@@ -369,6 +355,20 @@
         onSessionExtended: function(timeout)
         {
             $('#jTimedoutAlert').closeAlert();
+        },
+        /**
+         * Hides the countdown alert
+         */
+        hideCountdownAlert: function()
+        {
+            timeout.timeoutWarning = false;
+
+            var timeoutAlert = $('#jTimeoutAlert');
+
+            if (timeoutAlert.length > 0)
+            {
+                timeoutAlert.closeAlert();
+            }
         }
     };
 


### PR DESCRIPTION
I made the "hideCountdownAlert" function overriddable.  This way if someone wants to control their dialog/UI they'll be able to have it close properly across multiple windows.  Note:  "timeout.timeoutWarning = false;" should still be in the overridden method, or the pop-up won't display again and will continually fire "close" events.